### PR TITLE
Set up docker-compose for development purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+Install and run:
+
+1. `docker-compose up -d` to launch all the docker containers required for this app
+2. `docker exec -it test-php-fpm /bin/sh` into the php container. Within that container run `composer install` to generate the vendor directory containing various dependencies. You will see this appear in the applications source directory.
+3. `docker exec -it test-mariadb /bin/sh` into the database container. Within that container run `mysql -u test -p test < database.sql` to generate the database structure.
+4. You can now open the application at http://localhost:3000 and will be greeted by the welcome page.
+
+Your environment is now in a state where you can edit the various php files, when you refresh your browser, the latest state of your work will be visible because the source directory is loaded _live_ into the running containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.1"
+services:
+
+    mariadb:
+      image: mariadb:10.4
+      container_name: test-mariadb
+      working_dir: /application
+      volumes:
+        - .:/application
+      environment:
+        - MYSQL_ROOT_PASSWORD=root
+        - MYSQL_DATABASE=test
+        - MYSQL_USER=test
+        - MYSQL_PASSWORD=test
+      networks:
+        - heldnodig
+    
+
+    webserver:
+      image: nginx:alpine
+      container_name: test-webserver
+      working_dir: /application
+      volumes:
+          - .:/application
+          - ./phpdocker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      networks:
+        - heldnodig
+      ports:
+       - "3000:80"
+
+    php-fpm:
+      build: phpdocker/php-fpm
+      container_name: test-php-fpm
+      working_dir: /application
+      environment:
+        - MYSQLCONNSTR_localdb=db=test;HOST=mariadb;user=test;password=test
+      networks:
+        - heldnodig
+      volumes:
+        - .:/application
+        - ./phpdocker/php-fpm/php-ini-overrides.ini:/etc/php/7.4/fpm/conf.d/99-overrides.ini
+
+networks:
+  heldnodig:
+    driver: bridge

--- a/phpdocker/README.html
+++ b/phpdocker/README.html
@@ -1,0 +1,125 @@
+<html>
+<head>
+    <title>PHPDocker.io Readme</title>
+    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
+
+    <style>
+        code {
+            background-color : #ddd;
+            padding          : 2px 5px;
+            font-family      : monospace;
+            font-size        : 16px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="pure-g">
+    <div class="pure-u-1-24"></div>
+    <div class="pure-u-22-24">
+        <h1>PHPDocker.io generated environment</h1>
+
+<h1>Add to your project</h1>
+
+<p>Simply, unzip the file into your project, this will create <code>docker-compose.yml</code> on the root of your project and a folder named <code>phpdocker</code> containing nginx and php-fpm config for it.</p>
+
+<p>Ensure the webserver config on <code>phpdocker/nginx/nginx.conf</code> is correct for your project. PHPDocker.io will have customised this file according to the application type you chose on the generator, for instance <code>web/app|app_dev.php</code> on a Symfony project, or <code>public/index.php</code> on generic apps.</p>
+
+<p>Note: you may place the files elsewhere in your project. Make sure you modify the locations for the php-fpm dockerfile, the php.ini overrides and nginx config on <code>docker-compose.yml</code> if you do so.</p>
+
+<h1>How to run</h1>
+
+<p>Dependencies:</p>
+
+<ul>
+<li>Docker engine v1.13 or higher. Your OS provided package might be a little old, if you encounter problems, do upgrade. See <a href="https://docs.docker.com/engine/installation">https://docs.docker.com/engine/installation</a></li>
+<li>Docker compose v1.12 or higher. See <a href="https://docs.docker.com/compose/install/">docs.docker.com/compose/install</a></li>
+</ul>
+
+<p>Once you're done, simply <code>cd</code> to your project and run <code>docker-compose up -d</code>. This will initialise and start all the containers, then leave them running in the background.</p>
+
+<h2>Services exposed outside your environment</h2>
+
+<p>You can access your application via <strong><code>localhost</code></strong>, if you're running the containers directly, or through <strong>``</strong> when run on a vm. nginx and mailhog both respond to any hostname, in case you want to add your own hostname on your <code>/etc/hosts</code></p>
+
+<table>
+<thead>
+<tr>
+  <th>Service</th>
+  <th>Address outside containers</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>Webserver</td>
+  <td><a href="http://localhost:3000">localhost:3000</a></td>
+</tr>
+<tr>
+  <td>MariaDB</td>
+  <td><strong>host:</strong> <code>localhost</code>; <strong>port:</strong> <code>3003</code></td>
+</tr>
+</tbody>
+</table>
+
+<h2>Hosts within your environment</h2>
+
+<p>You'll need to configure your application to use any services you enabled:</p>
+
+<table>
+<thead>
+<tr>
+  <th>Service</th>
+  <th>Hostname</th>
+  <th>Port number</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>php-fpm</td>
+  <td>php-fpm</td>
+  <td>9000</td>
+</tr>
+<tr>
+  <td>MariaDB</td>
+  <td>mariadb</td>
+  <td>3306 (default)</td>
+</tr>
+</tbody>
+</table>
+
+<h1>Docker compose cheatsheet</h1>
+
+<p><strong>Note:</strong> you need to cd first to where your docker-compose.yml file lives.</p>
+
+<ul>
+<li>Start containers in the background: <code>docker-compose up -d</code></li>
+<li>Start containers on the foreground: <code>docker-compose up</code>. You will see a stream of logs for every container running.</li>
+<li>Stop containers: <code>docker-compose stop</code></li>
+<li>Kill containers: <code>docker-compose kill</code></li>
+<li>View container logs: <code>docker-compose logs</code></li>
+<li>Execute command inside of container: <code>docker-compose exec SERVICE_NAME COMMAND</code> where <code>COMMAND</code> is whatever you want to run. Examples:
+    * Shell into the PHP container, <code>docker-compose exec php-fpm bash</code>
+    * Run symfony console, <code>docker-compose exec php-fpm bin/console</code>
+    * Open a mysql shell, <code>docker-compose exec mysql mysql -uroot -pCHOSEN_ROOT_PASSWORD</code></li>
+</ul>
+
+<h1>Recommendations</h1>
+
+<p>It's hard to avoid file permission issues when fiddling about with containers due to the fact that, from your OS point of view, any files created within the container are owned by the process that runs the docker engine (this is usually root). Different OS will also have different problems, for instance you can run stuff in containers using <code>docker exec -it -u $(id -u):$(id -g) CONTAINER_NAME COMMAND</code> to force your current user ID into the process, but this will only work if your host OS is Linux, not mac. Follow a couple of simple rules and save yourself a world of hurt.</p>
+
+<ul>
+<li>Run composer outside of the php container, as doing so would install all your dependencies owned by <code>root</code> within your vendor folder.</li>
+<li>Run commands (ie Symfony's console, or Laravel's artisan) straight inside of your container. You can easily open a shell as described above and do your thing from there.</li>
+</ul>
+    </div>
+    <div class="pure-u-1-24"></div>
+</div>
+
+<script>
+    var tables = document.getElementsByTagName('table');
+    for (var i = 0; i < tables.length; i++) {
+        tables[i].className = "pure-table";
+    }
+</script>
+</body>
+</html>

--- a/phpdocker/README.md
+++ b/phpdocker/README.md
@@ -1,0 +1,58 @@
+PHPDocker.io generated environment
+==================================
+
+# Add to your project #
+
+Simply, unzip the file into your project, this will create `docker-compose.yml` on the root of your project and a folder named `phpdocker` containing nginx and php-fpm config for it.
+
+Ensure the webserver config on `phpdocker/nginx/nginx.conf` is correct for your project. PHPDocker.io will have customised this file according to the application type you chose on the generator, for instance `web/app|app_dev.php` on a Symfony project, or `public/index.php` on generic apps.
+
+Note: you may place the files elsewhere in your project. Make sure you modify the locations for the php-fpm dockerfile, the php.ini overrides and nginx config on `docker-compose.yml` if you do so.
+ 
+# How to run #
+
+Dependencies:
+
+  * Docker engine v1.13 or higher. Your OS provided package might be a little old, if you encounter problems, do upgrade. See [https://docs.docker.com/engine/installation](https://docs.docker.com/engine/installation)
+  * Docker compose v1.12 or higher. See [docs.docker.com/compose/install](https://docs.docker.com/compose/install/)
+
+Once you're done, simply `cd` to your project and run `docker-compose up -d`. This will initialise and start all the containers, then leave them running in the background.
+
+## Services exposed outside your environment ##
+
+You can access your application via **`localhost`**, if you're running the containers directly, or through **``** when run on a vm. nginx and mailhog both respond to any hostname, in case you want to add your own hostname on your `/etc/hosts` 
+
+Service|Address outside containers
+------|---------|-----------
+Webserver|[localhost:3000](http://localhost:3000)
+MariaDB|**host:** `localhost`; **port:** `3003`
+
+## Hosts within your environment ##
+
+You'll need to configure your application to use any services you enabled:
+
+Service|Hostname|Port number
+------|---------|-----------
+php-fpm|php-fpm|9000
+MariaDB|mariadb|3306 (default)
+
+# Docker compose cheatsheet #
+
+**Note:** you need to cd first to where your docker-compose.yml file lives.
+
+  * Start containers in the background: `docker-compose up -d`
+  * Start containers on the foreground: `docker-compose up`. You will see a stream of logs for every container running.
+  * Stop containers: `docker-compose stop`
+  * Kill containers: `docker-compose kill`
+  * View container logs: `docker-compose logs`
+  * Execute command inside of container: `docker-compose exec SERVICE_NAME COMMAND` where `COMMAND` is whatever you want to run. Examples:
+        * Shell into the PHP container, `docker-compose exec php-fpm bash`
+        * Run symfony console, `docker-compose exec php-fpm bin/console`
+        * Open a mysql shell, `docker-compose exec mysql mysql -uroot -pCHOSEN_ROOT_PASSWORD`
+
+# Recommendations #
+
+It's hard to avoid file permission issues when fiddling about with containers due to the fact that, from your OS point of view, any files created within the container are owned by the process that runs the docker engine (this is usually root). Different OS will also have different problems, for instance you can run stuff in containers using `docker exec -it -u $(id -u):$(id -g) CONTAINER_NAME COMMAND` to force your current user ID into the process, but this will only work if your host OS is Linux, not mac. Follow a couple of simple rules and save yourself a world of hurt.
+
+  * Run composer outside of the php container, as doing so would install all your dependencies owned by `root` within your vendor folder.
+  * Run commands (ie Symfony's console, or Laravel's artisan) straight inside of your container. You can easily open a shell as described above and do your thing from there.

--- a/phpdocker/nginx/nginx.conf
+++ b/phpdocker/nginx/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80 default;
+
+    client_max_body_size 108M;
+
+    access_log /var/log/nginx/application.access.log;
+
+
+    root /application;
+    index index.php;
+
+    if (!-e $request_filename) {
+        rewrite ^.*$ /index.php last;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass php-fpm:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PHP_VALUE "error_log=/var/log/nginx/application_php_errors.log";
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        include fastcgi_params;
+    }
+    
+}

--- a/phpdocker/php-fpm/Dockerfile
+++ b/phpdocker/php-fpm/Dockerfile
@@ -1,0 +1,10 @@
+FROM phpdockerio/php74-fpm:latest
+WORKDIR "/application"
+
+# Fix debconf warnings upon build
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install selected extensions and other stuff
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install  php7.4-mysql git zip \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*

--- a/phpdocker/php-fpm/php-ini-overrides.ini
+++ b/phpdocker/php-fpm/php-ini-overrides.ini
@@ -1,0 +1,2 @@
+upload_max_filesize = 100M
+post_max_size = 108M


### PR DESCRIPTION
Met deze docker-compose kun je een lokale ontwikkelomgeving draaien in docker zonder dat je op je gewone systeem php en mariadb hoeft te installeren. Doordat de bron-directory wordt gekoppeld kun je toch _live_ ontwikkelen en direct zien wat je doet. zie de README.md voor uitleg