### PR TITLE
#15 all input is passed by reference now.

### DIFF
--- a/classes/HeldNodig.php
+++ b/classes/HeldNodig.php
@@ -85,7 +85,10 @@ class HeldNodig
     {
         $query = "SELECT * FROM Hero WHERE (Mail=? AND IsVerifiedByMail=?) OR (Mail=? AND IsVerifiedByMail=? AND DateTimeCreated>?)";
         $stmt = $GLOBALS['database']->prepare($query);
-        $stmt->bind_param("sisis", $arg['mail'], 1, $arg['mail'], 0, date("Y-m-d H:i:s", time()-30*60));
+        // Can't pass in constants, variables to bind_param have to be passed by reference
+        $isverified = 1;
+        $isnotverified = 0;
+        $stmt->bind_param("sisis", $arg['mail'], $isverified, $arg['mail'], $isnotverified, date("Y-m-d H:i:s", time()-30*60));
         $stmt->execute();
         $result = $stmt->get_result();
             

--- a/classes/Request.php
+++ b/classes/Request.php
@@ -11,7 +11,9 @@ class Request extends Request_generated
     {
         $query = "SELECT * FROM Offer WHERE RequestId=? AND ((IsVerifiedByMail=? AND IsAccepted IS NULL) OR (IsAccepted=?))";
         $stmt = $GLOBALS['database']->prepare($query);
-        $stmt->bind_param("iii", $request->getId(), 1, 1);
+        $isverified = 1;
+        $isaccepted = 1;
+        $stmt->bind_param("iii", $request->getId(), $isverified, $isaccepted);
         $stmt->execute();
         $result = $stmt->get_result();
         $amountOfOffers = $result->num_rows;


### PR DESCRIPTION
I can't explain why this wasn't working. I suspect it has something to do with the docker container running php 7.4. But quickly can't explain that from PHP changelogs. Production is running 7.3 by the way. It would be better to downgrade the docker container for now to align those two.